### PR TITLE
Use 'from importlib import import_module'

### DIFF
--- a/jstemplate/finders.py
+++ b/jstemplate/finders.py
@@ -4,7 +4,7 @@ import warnings
 import glob, os, sys, re
 import six
 
-from django.utils.importlib import import_module
+from importlib import import_module
 
 from .conf import conf
 

--- a/jstemplate/loading.py
+++ b/jstemplate/loading.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 import six
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.importlib import import_module
+from importlib import import_module
 
 from .conf import conf
 


### PR DESCRIPTION
Fixes an error I encountered after upgrading to Django 1.9. Details here: http://stackoverflow.com/questions/32761566/django-1-9-importerror-for-import-module